### PR TITLE
Fix formatting for issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,13 +1,13 @@
 Date: `(<MM>/<DD>/2016)`
 
-###What I Did and Worked On (Yesterday):
+### What I Did and Worked On (Yesterday):
 - 
 
-###What I Will Do (Today):
+### What I Will Do (Today):
 - 
 
-###Any Blockers:
+### Any Blockers:
 - 
 
-###Interestings/Helps:
+### Interestings/Helps:
 - 


### PR DESCRIPTION
Added a space between `###` and the header title to fix the formatting.

![screenshot from 2016-05-24 01-10-48](https://cloud.githubusercontent.com/assets/6130147/15478378/78722b94-214c-11e6-9ef3-8840bc4d8d3c.png)

Fixed:
![screenshot from 2016-05-24 01-11-31](https://cloud.githubusercontent.com/assets/6130147/15478391/8fafac96-214c-11e6-99d7-e994d30a2f1a.png)
